### PR TITLE
Use $GITHUB_ENV to set environment variables

### DIFF
--- a/.github/actions/setup-lhci/main.sh
+++ b/.github/actions/setup-lhci/main.sh
@@ -2,15 +2,13 @@
 TODAY=$(date +%Y-%m-%d)
 YESTERDAY=$(date -v 1d +%Y-%m-%d)
 SHA=$(git rev-parse --short HEAD)
-
-function ctx() {
-  echo "::set-env name=LHCI_BUILD_CONTEXT__$1::$2"
-}
-
-ctx CURRENT_HASH "$SHA@$TODAY"
-ctx COMMIT_TIME "$TODAY"
-ctx CURRENT_BRANCH "$(git symbolic-ref --short HEAD)"
-ctx COMMIT_MESSAGE "Scheduled run: $TODAY"
-ctx AUTHOR "Actions <noreply@github.com>"
-ctx AVATAR_URL "https://avatars0.githubusercontent.com/in/15368?s=40&v=4"
-ctx ANCESTOR_HASH "$SHA@$YESTERDAY"
+REF=$(git symbolic-ref --short HEAD)
+(
+  echo "CURRENT_HASH=$SHA@$TODAY"
+  echo "COMMIT_TIME=$TODAY"
+  echo "CURRENT_BRANCH=$REF"
+  echo "COMMIT_MESSAGE=Scheduled run: $TODAY"
+  echo "AUTHOR=Actions <noreply@github.com>"
+  echo "AVATAR_URL=https://avatars0.githubusercontent.com/in/15368?s=40&v=4"
+  echo "ANCESTOR_HASH=$SHA@$YESTERDAY"
+) >> $GITHUB_ENV

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: echo "::set-env name=LHCI_GITHUB_TOKEN::${{ github.token }}"
+      - run: echo "LHCI_GITHUB_TOKEN=${{ github.token }}" >> $GITHUB_ENV
         if: github.event_name == 'push'
 
       - uses: ./.github/actions/setup-lhci


### PR DESCRIPTION
I noticed that [this run failed](https://github.com/SFDigitalServices/lighthouse-audit/actions/runs/367072362) and followed the link to [GitHub's blog post](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) and [the security advisory](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w) detailing problems with the Actions `set-env` command.

The fix is to write environment variable declarations to `$GITHUB_ENV`:

```diff
-echo "::set-env name=SOME_VAR::value"
+echo "SOME_VAR=value" >> $GITHUB_ENV
```